### PR TITLE
Change to onDeck poster img CSS

### DIFF
--- a/static/less/module-plex.less
+++ b/static/less/module-plex.less
@@ -60,7 +60,7 @@
             img
             {
                 width: 100%;
-                height: 120px;
+                margin-bottom: 22px;
                 .border-radius(4px);
             }
             p

--- a/static/less/module-plex.less
+++ b/static/less/module-plex.less
@@ -53,23 +53,42 @@
         {
             float: left;
             width: 18%;
-            overflow: hidden;
-            margin: 1%;
+            overflow: visible;
+            margin: 1% 1% 7%;
             position: relative;
             .border-radius(4px);
-            img
+            display: inline-block;
+            
+            &:before
             {
-                width: 100%;
-                margin-bottom: 22px;
+                content: "";
+                display: block;
+                padding-top: 150%;
+            }
+            
+            .posterimage
+            {
+                position: absolute;
+                top: 0;
+                left: 0;
+                bottom: 0;
+                right: 0;
+                background-repeat: no-repeat;
+                background-attachment: scroll;
+                background-size: contain;
+                background-position: center center;
+                border-radius: 5px;
+                z-index: 1;
                 .border-radius(4px);
             }
+            
             p
             {
                 background-color: black;
                 text-align: center;
                 line-height: 25px;
                 position: absolute;
-                bottom: 0;
+                bottom: -22px;
                 left: 0;
                 right: 0;
                 color: white;

--- a/templates/plex/on_deck.html
+++ b/templates/plex/on_deck.html
@@ -6,10 +6,10 @@
     {% for x in video %}
         <a class="poster" href="http://plex.tv/web/app#!/server/{{id}}/details/{{x['key']|replace('/', '%2F')}}" target="_blank">
             {% if "episode" in x['type'] %}
-                    <img src="{{x['grandparentThumb']|plex_img}}">
-                    <p>{{x['parentIndex']}}x{{x['index']}}</p>
+                <div class="posterimage" style="background-image: url({{x['grandparentThumb']|plex_img}})"></div>
+                <p>{{x['parentIndex']}}x{{x['index']}}</p>
             {% else %}
-                    <img src="{{ x['thumb']|plex_img}}">
+                <div class="posterimage" style="background-image: url({{ x['thumb']|plex_img}})"></div>
             {% endif %}
         </a>
     {% endfor %}


### PR DESCRIPTION
I made a small change to the onDeck poster image CSS so it doesn't look stretched.

before:
![before](https://cloud.githubusercontent.com/assets/6559052/2830385/51714eb8-cfae-11e3-844b-c1da00e427e2.PNG)

after:
![after](https://cloud.githubusercontent.com/assets/6559052/2830390/57b8e75e-cfae-11e3-90cc-d3c644335708.PNG)
